### PR TITLE
Rename core library files for workspace-session separation

### DIFF
--- a/docs/plan/workspace-session-separation.md
+++ b/docs/plan/workspace-session-separation.md
@@ -13,7 +13,7 @@ This plan separates two distinct concepts that were previously conflated:
 
 ## Progress Tracking
 
-- [ ] **Phase 1**: Complete Refactoring *(0/4 tasks)*
+- [ ] **Phase 1**: Complete Refactoring *(1/4 tasks)*
 - [ ] **Phase 2**: Object-Centric API Restructure *(0/3 tasks)*
 - [ ] **Phase 3**: Component Restructure *(0/4 tasks)*
 - [ ] **Phase 4**: Complete Integration *(0/4 tasks)*
@@ -25,11 +25,11 @@ This plan separates two distinct concepts that were previously conflated:
 **Goal**: Rename all concepts and update APIs immediately
 
 ### Tasks
-- [ ] **1.1** Rename core library files
-  - [ ] `src/lib/opencode-session.ts` → `src/lib/opencode-workspace.ts`
-  - [ ] `OpenCodeSession` → `OpenCodeWorkspace`
-  - [ ] `OpenCodeSessionManager` → `OpenCodeWorkspaceManager`
-  - [ ] `sessionManager` → `workspaceManager`
+- [x] ~~**1.1** Rename core library files~~ ✅ *Completed 2025-01-24*
+  - [x] ~~`src/lib/opencode-session.ts` → `src/lib/opencode-workspace.ts`~~
+  - [x] ~~`OpenCodeSession` → `OpenCodeWorkspace`~~
+  - [x] ~~`OpenCodeSessionManager` → `OpenCodeWorkspaceManager`~~
+  - [x] ~~`sessionManager` → `workspaceManager`~~
 
 - [ ] **1.2** Update data structures
   ```typescript

--- a/src/app/api/opencode-chat/route.ts
+++ b/src/app/api/opencode-chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { sessionManager } from "@/lib/opencode-session";
+import { workspaceManager } from "@/lib/opencode-workspace";
 import { withOpenCodeErrorHandling } from "@/lib/opencode-client";
 import type Opencode from "@opencode-ai/sdk";
 
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Get the session from the session manager
-    const session = sessionManager.getSession(sessionId);
+    const session = workspaceManager.getWorkspace(sessionId);
     if (!session) {
       return NextResponse.json(
         { error: `Session ${sessionId} not found` },
@@ -233,7 +233,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Get the session from the session manager
-    const session = sessionManager.getSession(sessionId);
+    const session = workspaceManager.getWorkspace(sessionId);
     if (!session) {
       return NextResponse.json(
         { error: `Session ${sessionId} not found` },

--- a/src/app/api/opencode/route.ts
+++ b/src/app/api/opencode/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { sessionManager } from "@/lib/opencode-session";
+import { workspaceManager } from "@/lib/opencode-workspace";
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const session = await sessionManager.startSession({ folder, model });
+    const session = await workspaceManager.startWorkspace({ folder, model });
 
     return NextResponse.json({
       sessionId: session.id,
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET() {
   try {
-    const sessions = sessionManager.getAllSessions();
+    const sessions = workspaceManager.getAllWorkspaces();
     return NextResponse.json({
       sessions: sessions.map(session => ({
         id: session.id,
@@ -61,7 +61,7 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    await sessionManager.stopSession(sessionId);
+    await workspaceManager.stopWorkspace(sessionId);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/hooks/useMessageSync.ts
+++ b/src/hooks/useMessageSync.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { Message as UseChatMessage } from "ai";
-import type { OpenCodeSession } from "@/lib/opencode-session";
+import type { OpenCodeWorkspace } from "@/lib/opencode-workspace";
 import { 
   messageSynchronizer, 
   type MessageSyncState, 
@@ -31,7 +31,7 @@ export interface UseMessageSyncReturn {
 }
 
 export function useMessageSync(
-  session: OpenCodeSession | null,
+  session: OpenCodeWorkspace | null,
   options: UseMessageSyncOptions = {}
 ): UseMessageSyncReturn {
   const [syncState, setSyncState] = useState<MessageSyncState | null>(null);

--- a/src/lib/message-sync.ts
+++ b/src/lib/message-sync.ts
@@ -3,7 +3,7 @@
 import type { Message as UseChatMessage } from "ai";
 import type { OpenCodeMessage } from "./message-types";
 import { messageConverter } from "./message-converter";
-import type { OpenCodeSession } from "./opencode-session";
+import type { OpenCodeWorkspace } from "./opencode-workspace";
 
 export interface MessageSyncState {
   lastSyncTimestamp: number;
@@ -68,7 +68,7 @@ export class MessageSynchronizer {
    */
   async synchronizeMessages(
     sessionId: string,
-    session: OpenCodeSession
+    session: OpenCodeWorkspace
   ): Promise<SyncResult> {
     const state = this.syncStates.get(sessionId);
     if (!state) {
@@ -152,7 +152,7 @@ export class MessageSynchronizer {
    */
   async getMessagesFromOpenCode(
     sessionId: string,
-    session: OpenCodeSession
+    session: OpenCodeWorkspace
   ): Promise<UseChatMessage[]> {
     try {
       const openCodeMessages = await this.getOpenCodeMessages(session);
@@ -235,7 +235,7 @@ export class MessageSynchronizer {
   /**
    * Get messages from OpenCode session
    */
-  private async getOpenCodeMessages(session: OpenCodeSession): Promise<OpenCodeMessage[]> {
+  private async getOpenCodeMessages(session: OpenCodeWorkspace): Promise<OpenCodeMessage[]> {
     if (!session.client || session.status !== "running") {
       return [];
     }


### PR DESCRIPTION
## Summary
- Implements Phase 1, Task 1.1 of the workspace-session separation plan
- Renames `opencode-session.ts` → `opencode-workspace.ts` and updates all class names, manager names, and variable references
- Establishes proper terminology foundation for separating workspace (OpenCode instance) from session (chat conversation) concepts

## Test plan
- [x] Verify all imports and references updated correctly
- [x] Run lint checks to ensure no TypeScript errors
- [x] Confirm existing functionality remains intact
- [x] Update plan documentation to mark task as completed

🤖 Generated with [opencode](https://opencode.ai)