### PR TITLE
Add workspace dashboard navigation with streamlined UI

### DIFF
--- a/src/components/workspace-dashboard.tsx
+++ b/src/components/workspace-dashboard.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { Button } from "../../button";
 import { cn } from "@/lib/utils";
-import { AlertTriangleIcon, CheckCircleIcon, FolderIcon, BrainIcon, ServerIcon } from "lucide-react";
+import { AlertTriangleIcon, CheckCircleIcon, FolderIcon, BrainIcon, ServerIcon, MessageSquareIcon, XIcon } from "lucide-react";
+import SessionManager from "./session-manager";
 
 interface WorkspaceData {
   workspaceId: string;
@@ -15,12 +16,14 @@ interface WorkspaceData {
 interface WorkspaceDashboardProps {
   workspaceData: WorkspaceData;
   onWorkspaceStop: () => void;
+  onOpenChat: () => void;
   className?: string;
 }
 
-export default function WorkspaceDashboard({ workspaceData, onWorkspaceStop, className }: WorkspaceDashboardProps) {
+export default function WorkspaceDashboard({ workspaceData, onWorkspaceStop, onOpenChat, className }: WorkspaceDashboardProps) {
   const [isStopping, setIsStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showSessionManager, setShowSessionManager] = useState(false);
 
   const handleStopWorkspace = async () => {
     setIsStopping(true);
@@ -93,13 +96,14 @@ export default function WorkspaceDashboard({ workspaceData, onWorkspaceStop, cla
           </div>
         )}
 
-        <div className="flex gap-4 justify-center">
+        <div className="flex gap-4 justify-center mb-6">
           <Button
-            onClick={openInBrowser}
+            onClick={() => setShowSessionManager(true)}
             size="lg"
             className="flex-1 bg-primary/90 hover:bg-primary"
           >
-            Open Dashboard
+            <MessageSquareIcon className="w-5 h-5 mr-2" />
+            Manage Sessions
           </Button>
           
           <Button
@@ -112,11 +116,23 @@ export default function WorkspaceDashboard({ workspaceData, onWorkspaceStop, cla
             {isStopping ? (
               <>
                 <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-current mr-2"></div>
-                Stopping...
+                Deleting...
               </>
             ) : (
-              "Stop Workspace"
+              "Delete Workspace"
             )}
+          </Button>
+        </div>
+
+        <div className="text-center">
+          <Button
+            onClick={openInBrowser}
+            variant="outline"
+            size="lg"
+            className="w-full max-w-md"
+          >
+            <ServerIcon className="w-5 h-5 mr-2" />
+            Open in Browser
           </Button>
         </div>
 
@@ -124,6 +140,37 @@ export default function WorkspaceDashboard({ workspaceData, onWorkspaceStop, cla
           <p>Workspace ID: <span className="font-mono">{workspaceData.workspaceId}</span></p>
         </div>
       </div>
+
+      {/* Session Management Modal */}
+      {showSessionManager && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-background p-6 rounded-lg shadow-xl max-w-4xl w-full mx-4 border border-border max-h-[80vh] overflow-y-auto">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h3 className="text-xl font-semibold text-foreground">Manage Sessions</h3>
+                <p className="text-muted-foreground text-sm mt-1">
+                  Workspace: {workspaceData.folder.split("/").pop()}
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowSessionManager(false)}
+              >
+                <XIcon className="w-4 h-4" />
+              </Button>
+            </div>
+            <SessionManager
+              workspaceId={workspaceData.workspaceId}
+              onOpenChat={(sessionId) => {
+                console.log("Opening chat for session:", sessionId);
+                setShowSessionManager(false);
+                onOpenChat();
+              }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/workspace-manager.tsx
+++ b/src/components/workspace-manager.tsx
@@ -4,19 +4,18 @@ import { useState } from "react";
 import { Button } from "../../button";
 import { cn } from "@/lib/utils";
 import { useOpenCodeSession } from "@/hooks/useOpenCodeWorkspace";
-import { PlusIcon, TrashIcon, PlayIcon, FolderIcon, BrainIcon, ServerIcon, MessageSquareIcon, XIcon } from "lucide-react";
+import { PlusIcon, TrashIcon, FolderIcon, BrainIcon, ServerIcon, MessageSquareIcon } from "lucide-react";
 import FolderSelector from "./folder-selector";
 import ModelSelector from "./model-selector";
-import SessionManager from "./session-manager";
 
 interface WorkspaceManagerProps {
   className?: string;
-  onOpenChat?: () => void;
+  onOpenWorkspace?: (workspaceId: string) => void;
 }
 
 type CreateWorkspaceState = "idle" | "folder-selection" | "model-selection" | "creating";
 
-export default function WorkspaceManager({ className, onOpenChat }: WorkspaceManagerProps) {
+export default function WorkspaceManager({ className, onOpenWorkspace }: WorkspaceManagerProps) {
   const {
     sessions: workspaces,
     currentSession: currentWorkspace,
@@ -24,7 +23,7 @@ export default function WorkspaceManager({ className, onOpenChat }: WorkspaceMan
     error,
     createSession: createWorkspace,
     stopSession: stopWorkspace,
-    switchToSession: switchToWorkspace,
+
     clearError,
   } = useOpenCodeSession();
 
@@ -32,7 +31,7 @@ export default function WorkspaceManager({ className, onOpenChat }: WorkspaceMan
   const [selectedFolder, setSelectedFolder] = useState<string | null>(null);
   const [, setSelectedModel] = useState<string | null>(null);
   const [workspaceToDelete, setWorkspaceToDelete] = useState<string | null>(null);
-  const [sessionManagementWorkspaceId, setSessionManagementWorkspaceId] = useState<string | null>(null);
+
 
   const handleCreateWorkspaceClick = () => {
     setCreateWorkspaceState("folder-selection");
@@ -230,37 +229,9 @@ export default function WorkspaceManager({ className, onOpenChat }: WorkspaceMan
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={async () => {
-                        console.log("🚀 Open Chat clicked for workspace:", workspace.id);
-                        await switchToWorkspace(workspace.id);
-                        console.log("📞 Calling onOpenChat callback");
-                        // Add a small delay to ensure React state has updated
-                        setTimeout(() => {
-                          onOpenChat?.();
-                        }, 10);
-                      }}
+                      onClick={() => onOpenWorkspace?.(workspace.id)}
                     >
-                      Open Chat
-                    </Button>
-                  )}
-                  {workspace.status === "running" && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setSessionManagementWorkspaceId(workspace.id)}
-                      title="Manage sessions in this workspace"
-                    >
-                      <MessageSquareIcon className="w-4 h-4" />
-                    </Button>
-                  )}
-                  {workspace.status === "running" && currentWorkspace?.id !== workspace.id && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => switchToWorkspace(workspace.id)}
-                      title="Set as active workspace"
-                    >
-                      <PlayIcon className="w-4 h-4" />
+                      Open Workspace
                     </Button>
                   )}
                   <Button
@@ -269,7 +240,8 @@ export default function WorkspaceManager({ className, onOpenChat }: WorkspaceMan
                     onClick={() => setWorkspaceToDelete(workspace.id)}
                     className="text-destructive hover:text-destructive hover:bg-destructive/10"
                   >
-                    <TrashIcon className="w-4 h-4" />
+                    <TrashIcon className="w-4 h-4 mr-1" />
+                    Delete Workspace
                   </Button>
                 </div>
               </div>
@@ -305,36 +277,7 @@ export default function WorkspaceManager({ className, onOpenChat }: WorkspaceMan
         </div>
       )}
 
-      {/* Session Management Modal */}
-      {sessionManagementWorkspaceId && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-background p-6 rounded-lg shadow-xl max-w-4xl w-full mx-4 border border-border max-h-[80vh] overflow-y-auto">
-            <div className="flex items-center justify-between mb-6">
-              <div>
-                <h3 className="text-xl font-semibold text-foreground">Manage Sessions</h3>
-                <p className="text-muted-foreground text-sm mt-1">
-                  Workspace: {workspaces.find(w => w.id === sessionManagementWorkspaceId)?.folder.split("/").pop()}
-                </p>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setSessionManagementWorkspaceId(null)}
-              >
-                <XIcon className="w-4 h-4" />
-              </Button>
-            </div>
-            <SessionManager
-              workspaceId={sessionManagementWorkspaceId}
-              onOpenChat={(sessionId) => {
-                console.log("Opening chat for session:", sessionId);
-                setSessionManagementWorkspaceId(null);
-                onOpenChat?.();
-              }}
-            />
-          </div>
-        </div>
-      )}
+
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace multiple workspace action buttons with streamlined "Open Workspace" and "Delete Workspace" buttons
- Add dedicated workspace dashboard view that consolidates session management and workspace details in a single interface

## Test plan
- [ ] Verify workspace list shows only "Open Workspace" and "Delete Workspace" buttons for each workspace
- [ ] Test "Open Workspace" button navigates to workspace dashboard with correct workspace details
- [ ] Verify workspace dashboard shows workspace info (server URL, folder, model)
- [ ] Test "Manage Sessions" button opens session management modal
- [ ] Verify "Delete Workspace" button works from both workspace list and dashboard
- [ ] Test "Open in Browser" button opens workspace server in new tab
- [ ] Verify navigation back to workspace list works correctly

🤖 Generated with [opencode](https://opencode.ai)