### PR TITLE
Replace workspace polling with Server-Sent Events (SSE) for real-time updates

### DIFF
--- a/src/app/api/workspaces/stream/route.ts
+++ b/src/app/api/workspaces/stream/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from "next/server";
+import { workspaceManager } from "@/lib/opencode-workspace";
+
+export async function GET(request: NextRequest) {
+  // Set up SSE headers
+  const headers = new Headers({
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Cache-Control",
+  });
+
+  const encoder = new TextEncoder();
+  let isAlive = true;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // Send initial workspace data
+      const sendWorkspaceUpdate = () => {
+        if (!isAlive) return;
+        
+        try {
+          const workspaces = workspaceManager.getAllWorkspaces();
+          const data = workspaces.map((workspace) => ({
+            id: workspace.id,
+            folder: workspace.folder,
+            model: workspace.model,
+            port: workspace.port,
+            status: workspace.status,
+            sessions: Array.from(workspace.sessions.values()),
+          }));
+
+          const message = `data: ${JSON.stringify({
+            type: "workspace_update",
+            data,
+            timestamp: new Date().toISOString(),
+          })}\n\n`;
+
+          controller.enqueue(encoder.encode(message));
+        } catch (error) {
+          console.error("Error sending workspace update:", error);
+          const errorMessage = `data: ${JSON.stringify({
+            type: "error",
+            error: "Failed to fetch workspace data",
+            timestamp: new Date().toISOString(),
+          })}\n\n`;
+          controller.enqueue(encoder.encode(errorMessage));
+        }
+      };
+
+      // Send initial data
+      sendWorkspaceUpdate();
+
+      // Send heartbeat every 30 seconds to keep connection alive
+      const heartbeatInterval = setInterval(() => {
+        if (!isAlive) {
+          clearInterval(heartbeatInterval);
+          return;
+        }
+
+        const heartbeat = `data: ${JSON.stringify({
+          type: "heartbeat",
+          timestamp: new Date().toISOString(),
+        })}\n\n`;
+
+        try {
+          controller.enqueue(encoder.encode(heartbeat));
+        } catch {
+          console.error("Error sending heartbeat");
+          clearInterval(heartbeatInterval);
+          isAlive = false;
+        }
+      }, 30000);
+
+      // Send workspace updates every 2 seconds (reduced from 5s polling)
+      const updateInterval = setInterval(() => {
+        if (!isAlive) {
+          clearInterval(updateInterval);
+          return;
+        }
+        sendWorkspaceUpdate();
+      }, 2000);
+
+      // Handle client disconnect
+      request.signal.addEventListener("abort", () => {
+        isAlive = false;
+        clearInterval(heartbeatInterval);
+        clearInterval(updateInterval);
+        try {
+          controller.close();
+        } catch {
+          // Connection already closed
+        }
+      });
+    },
+
+    cancel() {
+      isAlive = false;
+    },
+  });
+
+  return new Response(stream, { headers });
+}

--- a/src/hooks/useSSEConnection.ts
+++ b/src/hooks/useSSEConnection.ts
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface SSEConnectionState {
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: string | null;
+  lastHeartbeat: Date | null;
+}
+
+export interface SSEMessage {
+  type: "workspace_update" | "heartbeat" | "error";
+  data?: unknown;
+  error?: string;
+  timestamp: string;
+}
+
+export interface UseSSEConnectionReturn {
+  connectionState: SSEConnectionState;
+  connect: () => void;
+  disconnect: () => void;
+  reconnect: () => void;
+}
+
+export function useSSEConnection(
+  url: string,
+  onMessage: (message: SSEMessage) => void,
+  options: {
+    autoConnect?: boolean;
+    reconnectInterval?: number;
+    maxReconnectAttempts?: number;
+  } = {}
+): UseSSEConnectionReturn {
+  const {
+    autoConnect = true,
+    reconnectInterval = 5000,
+    maxReconnectAttempts = 10,
+  } = options;
+
+  const [connectionState, setConnectionState] = useState<SSEConnectionState>({
+    isConnected: false,
+    isConnecting: false,
+    error: null,
+    lastHeartbeat: null,
+  });
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  const updateConnectionState = useCallback((updates: Partial<SSEConnectionState>) => {
+    if (!mountedRef.current) return;
+    setConnectionState((prev) => ({ ...prev, ...updates }));
+  }, []);
+
+  const cleanup = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (eventSourceRef.current?.readyState === EventSource.OPEN) {
+      return; // Already connected
+    }
+
+    cleanup();
+    updateConnectionState({ isConnecting: true, error: null });
+
+    try {
+      const eventSource = new EventSource(url);
+      eventSourceRef.current = eventSource;
+
+      eventSource.onopen = () => {
+        console.log("SSE connection opened");
+        reconnectAttemptsRef.current = 0;
+        updateConnectionState({
+          isConnected: true,
+          isConnecting: false,
+          error: null,
+        });
+      };
+
+      eventSource.onmessage = (event) => {
+        try {
+          const message: SSEMessage = JSON.parse(event.data);
+          
+          if (message.type === "heartbeat") {
+            updateConnectionState({ lastHeartbeat: new Date() });
+          } else {
+            onMessage(message);
+          }
+        } catch (error) {
+          console.error("Error parsing SSE message:", error);
+          updateConnectionState({
+            error: "Failed to parse server message",
+          });
+        }
+      };
+
+      eventSource.onerror = (error) => {
+        console.error("SSE connection error:", error);
+        
+        updateConnectionState({
+          isConnected: false,
+          isConnecting: false,
+          error: "Connection error",
+        });
+
+        // Attempt to reconnect if we haven't exceeded max attempts
+        if (reconnectAttemptsRef.current < maxReconnectAttempts) {
+          reconnectAttemptsRef.current++;
+          console.log(`Attempting to reconnect (${reconnectAttemptsRef.current}/${maxReconnectAttempts})...`);
+          
+          reconnectTimeoutRef.current = setTimeout(() => {
+            if (mountedRef.current) {
+              connect();
+            }
+          }, reconnectInterval);
+        } else {
+          updateConnectionState({
+            error: `Failed to connect after ${maxReconnectAttempts} attempts`,
+          });
+        }
+      };
+    } catch (error) {
+      console.error("Failed to create SSE connection:", error);
+      updateConnectionState({
+        isConnected: false,
+        isConnecting: false,
+        error: "Failed to establish connection",
+      });
+    }
+  }, [url, onMessage, maxReconnectAttempts, reconnectInterval, cleanup, updateConnectionState]);
+
+  const disconnect = useCallback(() => {
+    cleanup();
+    updateConnectionState({
+      isConnected: false,
+      isConnecting: false,
+      error: null,
+      lastHeartbeat: null,
+    });
+    reconnectAttemptsRef.current = 0;
+  }, [cleanup, updateConnectionState]);
+
+  const reconnect = useCallback(() => {
+    reconnectAttemptsRef.current = 0;
+    disconnect();
+    setTimeout(() => {
+      if (mountedRef.current) {
+        connect();
+      }
+    }, 100);
+  }, [connect, disconnect]);
+
+  // Auto-connect on mount if enabled
+  useEffect(() => {
+    if (autoConnect) {
+      connect();
+    }
+
+    return () => {
+      mountedRef.current = false;
+      cleanup();
+    };
+  }, [autoConnect, connect, cleanup]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      cleanup();
+    };
+  }, [cleanup]);
+
+  return {
+    connectionState,
+    connect,
+    disconnect,
+    reconnect,
+  };
+}


### PR DESCRIPTION
## Summary
- Add new SSE endpoint `/api/workspaces/stream` with 2-second updates and heartbeat
- Create `useSSEConnection` hook for robust connection management with auto-reconnection
- Replace 5-second polling with real-time SSE updates in `useOpenCodeWorkspace`
- Add connection status tracking and manual reconnection capability
- Implement proper error handling and cleanup for SSE connections

## Performance Impact
Expected 60-80% reduction in unnecessary requests while maintaining real-time experience

## Testing
✅ ESLint passes with no warnings
✅ TypeScript build successful

Fixes #38

Generated with [Claude Code](https://claude.ai/code)