### PR TITLE
Refactor: Switch from Anthropic to Groq model in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           npm run test:install
           npm run test -- -n 0 -s -x tests/${{ matrix.test-file }}
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 
   test:
     runs-on: ubuntu-latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,7 +339,7 @@ def test_folder(server_manager: TestServerManager) -> str:
 @pytest.fixture
 def test_model() -> str:
     """Default model to use in tests."""
-    return "anthropic/claude-3-5-haiku-20241022"
+    return "groq/openai/gpt-oss-20b"
 
 
 @pytest.fixture

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -61,7 +61,7 @@ async def test_health_endpoint_basic(client: httpx.AsyncClient):
     print("✅ Health endpoint test passed - cleanup system is properly initialized")
 
 
-async def test_health_endpoint_with_workspace(client: httpx.AsyncClient):
+async def test_health_endpoint_with_workspace(client: httpx.AsyncClient, test_model: str):
     """Test health endpoint when workspaces are running."""
     
     import tempfile
@@ -80,7 +80,7 @@ async def test_health_endpoint_with_workspace(client: httpx.AsyncClient):
             # Create workspace
             response = await client.post("/api/workspaces", json={
                 "folder": test_folder,
-                "model": "anthropic/claude-3-5-haiku-20241022"
+                "model": test_model
             })
             
             if response.status_code != 200:
@@ -108,7 +108,7 @@ async def test_health_endpoint_with_workspace(client: httpx.AsyncClient):
                 if workspace["id"] == workspace_id:
                     workspace_found = True
                     assert workspace["folder"] == test_folder
-                    assert workspace["model"] == "anthropic/claude-3-5-haiku-20241022"
+                    assert workspace["model"] == test_model
                     assert "status" in workspace
                     assert "sessionCount" in workspace
                     assert "hasProcess" in workspace

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,7 @@ class TestOtherEndpoints:
         # This endpoint behavior depends on implementation
         assert response.status_code in [200, 404, 405, 500]
 
-    async def test_opencode_chat_endpoint(self, client: httpx.AsyncClient):
+    async def test_opencode_chat_endpoint(self, client: httpx.AsyncClient, test_model: str):
         """Test the opencode-chat endpoint."""
         # Try GET without sessionId - should return 400
         get_response = await client.get("/api/opencode-chat")
@@ -231,6 +231,6 @@ class TestOtherEndpoints:
         post_response_invalid_session = await client.post("/api/opencode-chat", json={
             "sessionId": "invalid-session",
             "messages": [{"role": "user", "content": "test"}],
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert post_response_invalid_session.status_code == 404

--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -12,13 +12,13 @@ from .test_utils import parse_opencode_streaming_chunk
 class TestOpenCodeClient:
     """Test cases for OpenCode client integration and tool call parsing."""
 
-    async def test_opencode_client_session_creation(self, client: httpx.AsyncClient, test_workspace):
+    async def test_opencode_client_session_creation(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test creating a session through OpenCode client and verifying tool call parsing."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         
         assert response.status_code == 200
@@ -28,16 +28,16 @@ class TestOpenCodeClient:
         # Verify session structure
         assert "id" in session_data
         assert "model" in session_data
-        assert session_data["model"] == "anthropic/claude-3-5-haiku-20241022"
+        assert session_data["model"] == test_model
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_opencode_chat_with_tool_calls(self, client: httpx.AsyncClient, test_workspace):
+    async def test_opencode_chat_with_tool_calls(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test sending a message that triggers tool calls and verify parsing."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -97,13 +97,13 @@ class TestOpenCodeClient:
         assert tool_results_found, "No tool results found in response"
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_opencode_streaming_with_tool_calls(self, client: httpx.AsyncClient, test_workspace):
+    async def test_opencode_streaming_with_tool_calls(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test streaming chat with tool calls and verify parsing."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -149,7 +149,7 @@ class TestOpenCodeClient:
             # Note: The exact structure depends on the OpenCode SDK streaming format
             # We're mainly testing that the parsing doesn't break and we get valid JSON
 
-    async def test_opencode_error_handling(self, client: httpx.AsyncClient, test_workspace):
+    async def test_opencode_error_handling(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test error handling in OpenCode client operations."""
         workspace_id = test_workspace["id"]
         
@@ -182,13 +182,13 @@ class TestOpenCodeClient:
         assert malformed_response.status_code in [400, 422, 500]
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_tool_call_argument_parsing(self, client: httpx.AsyncClient, test_workspace):
+    async def test_tool_call_argument_parsing(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test that tool call arguments are properly parsed and validated."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -262,14 +262,14 @@ class TestOpenCodeClient:
             assert len(tool_calls_with_complex_args) > 0, "No tool calls with complex arguments found"
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_concurrent_opencode_sessions(self, client: httpx.AsyncClient, test_workspace):
+    async def test_concurrent_opencode_sessions(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test multiple concurrent OpenCode sessions and tool call parsing."""
         workspace_id = test_workspace["id"]
         
         async def create_session_and_chat():
             # Create a session
             session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-                "model": "anthropic/claude-3-5-haiku-20241022"
+                "model": test_model
             })
             assert session_response.status_code == 200
             session_data = session_response.json()
@@ -315,13 +315,13 @@ class TestOpenCodeClient:
             assert len(message["parts"]) > 0
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_tool_call_result_parsing(self, client: httpx.AsyncClient, test_workspace):
+    async def test_tool_call_result_parsing(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test that tool call results are properly parsed and structured."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -372,13 +372,13 @@ class TestOpenCodeClient:
             assert len(tool_result_ids) > 0, "No tool results found despite tool calls"
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_opencode_session_persistence(self, client: httpx.AsyncClient, test_workspace):
+    async def test_opencode_session_persistence(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test that OpenCode sessions maintain state across multiple messages."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()

--- a/tests/test_opencode_server_leak.py
+++ b/tests/test_opencode_server_leak.py
@@ -93,7 +93,7 @@ def process_tracker():
     tracker.force_cleanup_leaked_processes()
 
 
-async def test_opencode_server_leak_on_shutdown(client: httpx.AsyncClient, process_tracker: ProcessTracker):
+async def test_opencode_server_leak_on_shutdown(client: httpx.AsyncClient, process_tracker: ProcessTracker, test_model: str):
     """
     Test that OpenCode server instances are properly cleaned up when workspaces are stopped.
     
@@ -125,7 +125,7 @@ async def test_opencode_server_leak_on_shutdown(client: httpx.AsyncClient, proce
             # Create workspace
             response = await client.post("/api/workspaces", json={
                 "folder": test_folder,
-                "model": "anthropic/claude-3-5-haiku-20241022"
+                "model": test_model
             })
             
             assert response.status_code == 200, f"Failed to create workspace {i}: {response.text}"
@@ -145,7 +145,7 @@ async def test_opencode_server_leak_on_shutdown(client: httpx.AsyncClient, proce
         session_ids = []
         for workspace_id in workspace_ids:
             response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-                "model": "anthropic/claude-3-5-haiku-20241022"
+                "model": test_model
             })
             assert response.status_code == 200, f"Failed to create session for workspace {workspace_id}"
             session_data = response.json()
@@ -199,7 +199,7 @@ async def test_opencode_server_leak_on_shutdown(client: httpx.AsyncClient, proce
                 print(f"Warning: Could not cleanup test folder {test_folder}: {e}")
 
 
-async def test_opencode_server_leak_on_app_shutdown(base_url: str, process_tracker: ProcessTracker):
+async def test_opencode_server_leak_on_app_shutdown(base_url: str, process_tracker: ProcessTracker, test_model: str):
     """
     Test that OpenCode server instances are cleaned up when the entire web app shuts down.
     
@@ -272,7 +272,7 @@ async def test_opencode_server_leak_on_app_shutdown(base_url: str, process_track
                     
                     response = await test_client.post("/api/workspaces", json={
                         "folder": test_folder,
-                        "model": "anthropic/claude-3-5-haiku-20241022"
+                        "model": test_model
                     })
                     
                     if response.status_code == 200:
@@ -340,7 +340,7 @@ async def test_opencode_server_leak_on_app_shutdown(base_url: str, process_track
                     app_process.wait()
 
 
-async def test_opencode_server_cleanup_on_sigterm(process_tracker: ProcessTracker):
+async def test_opencode_server_cleanup_on_sigterm(process_tracker: ProcessTracker, test_model: str):
     """
     Test that OpenCode server instances are cleaned up when the web app receives SIGTERM.
     
@@ -404,7 +404,7 @@ async def test_opencode_server_cleanup_on_sigterm(process_tracker: ProcessTracke
                 
                 response = await test_client.post("/api/workspaces", json={
                     "folder": test_folder,
-                    "model": "anthropic/claude-3-5-haiku-20241022"
+                    "model": test_model
                 })
                 
                 if response.status_code != 200:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -136,14 +136,14 @@ class TestSessions:
         assert session1["id"] in session_ids
         assert session2["id"] in session_ids
 
-    async def test_session_different_models(self, client: httpx.AsyncClient, test_workspace):
+    async def test_session_different_models(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test creating sessions with different models."""
         workspace_id = test_workspace["id"]
         
         models_to_test = [
+            test_model,  # Use the test model fixture as primary test
             "openai/gpt-4o-mini",
-            "openai/gpt-4o",
-            "anthropic/claude-3-5-sonnet-20241022"
+            "openai/gpt-4o"
         ]
         
         session_ids = []

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -259,7 +259,7 @@ class TestWorkspaceStream:
                     break
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_stream_with_opencode_session_activity(self, client: httpx.AsyncClient, test_workspace):
+    async def test_stream_with_opencode_session_activity(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test that stream updates when OpenCode sessions are active and parsing tool calls."""
         workspace_id = test_workspace["id"]
         
@@ -288,7 +288,7 @@ class TestWorkspaceStream:
         
         # Create a session and send a message that triggers tool calls
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -349,13 +349,13 @@ class TestWorkspaceStream:
                 # This is acceptable as the stream is eventually consistent
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_stream_tool_call_parsing_integration(self, client: httpx.AsyncClient, test_workspace):
+    async def test_stream_tool_call_parsing_integration(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test stream integration with OpenCode tool call parsing."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -431,7 +431,7 @@ class TestWorkspaceStream:
         assert len(workspace_updates) > 0, "No workspace updates found in stream"
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_stream_concurrent_tool_call_sessions(self, client: httpx.AsyncClient, test_workspace):
+    async def test_stream_concurrent_tool_call_sessions(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test stream behavior with multiple concurrent sessions using tool calls."""
         workspace_id = test_workspace["id"]
         
@@ -462,7 +462,7 @@ class TestWorkspaceStream:
         async def create_session_and_chat(message: str):
             # Create a session
             session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-                "model": "anthropic/claude-3-5-haiku-20241022"
+                "model": test_model
             })
             assert session_response.status_code == 200
             session_data = session_response.json()
@@ -535,13 +535,13 @@ class TestWorkspaceStream:
         assert max_sessions_seen >= 2, f"Expected to see at least 2 concurrent sessions, saw {max_sessions_seen}"
 
     @pytest.mark.skip(reason="Flaky test due to model variability in tool call generation")
-    async def test_stream_tool_call_error_handling(self, client: httpx.AsyncClient, test_workspace):
+    async def test_stream_tool_call_error_handling(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test stream behavior when tool calls encounter errors."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()

--- a/tests/test_tool_call_parsing.py
+++ b/tests/test_tool_call_parsing.py
@@ -14,13 +14,13 @@ from .test_utils import parse_opencode_streaming_chunk
 class TestToolCallParsing:
     """Comprehensive tests for OpenCode tool call parsing logic."""
 
-    async def test_basic_tool_call_structure_parsing(self, client: httpx.AsyncClient, test_workspace):
+    async def test_basic_tool_call_structure_parsing(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test that basic tool call structures are parsed correctly."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -59,13 +59,13 @@ class TestToolCallParsing:
         for tool_call in tool_calls:
             self._validate_tool_call_structure(tool_call)
 
-    async def test_complex_tool_call_arguments_parsing(self, client: httpx.AsyncClient, test_workspace):
+    async def test_complex_tool_call_arguments_parsing(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test parsing of complex tool call arguments."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -159,13 +159,13 @@ class TestToolCallParsing:
                     # Just validate that the tool call has proper structure
                     assert isinstance(args, dict), f"Tool arguments should be a dict: {args}"
 
-    async def test_streaming_tool_call_parsing(self, client: httpx.AsyncClient, test_workspace):
+    async def test_streaming_tool_call_parsing(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test parsing of tool calls in streaming responses."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -216,13 +216,13 @@ class TestToolCallParsing:
                     assert "name" in function_delta or "arguments" in function_delta, \
                         f"Function delta missing name/arguments: {function_delta}"
 
-    async def test_tool_call_result_correlation(self, client: httpx.AsyncClient, test_workspace):
+    async def test_tool_call_result_correlation(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test that tool call results are properly correlated with their calls."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -278,13 +278,13 @@ class TestToolCallParsing:
                 assert "content" in result or ("state" in result and "output" in result["state"]), \
                     f"Tool result for {call_id} missing content/output: {result}"
 
-    async def test_malformed_tool_call_handling(self, client: httpx.AsyncClient, test_workspace):
+    async def test_malformed_tool_call_handling(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test handling of potentially malformed tool calls."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -321,7 +321,7 @@ class TestToolCallParsing:
         for tool_call in tool_calls:
             self._validate_tool_call_structure(tool_call)
 
-    async def test_concurrent_tool_call_parsing(self, client: httpx.AsyncClient, test_workspace):
+    async def test_concurrent_tool_call_parsing(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test tool call parsing under concurrent load."""
         workspace_id = test_workspace["id"]
         
@@ -346,7 +346,7 @@ class TestToolCallParsing:
         sessions = []
         for i in range(3):
             session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-                "model": "anthropic/claude-3-5-haiku-20241022"
+                "model": test_model
             })
             assert session_response.status_code == 200
             sessions.append(session_response.json())
@@ -390,13 +390,13 @@ class TestToolCallParsing:
             for tool_call in tool_calls:
                 self._validate_tool_call_structure(tool_call)
 
-    async def test_tool_call_argument_edge_cases(self, client: httpx.AsyncClient, test_workspace):
+    async def test_tool_call_argument_edge_cases(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test parsing of tool call arguments with edge cases."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()
@@ -439,13 +439,13 @@ class TestToolCallParsing:
                     args = tool_call["state"]["input"]
                     assert isinstance(args, dict), "Arguments should be a dictionary"
 
-    async def test_tool_call_parsing_performance(self, client: httpx.AsyncClient, test_workspace):
+    async def test_tool_call_parsing_performance(self, client: httpx.AsyncClient, test_workspace, test_model: str):
         """Test performance of tool call parsing with large responses."""
         workspace_id = test_workspace["id"]
         
         # Create a session
         session_response = await client.post(f"/api/workspaces/{workspace_id}/sessions", json={
-            "model": "anthropic/claude-3-5-haiku-20241022"
+            "model": test_model
         })
         assert session_response.status_code == 200
         session_data = session_response.json()


### PR DESCRIPTION
## Summary
- Refactor all test files to use `test_model` fixture instead of hard-coded model strings
- Update `test_model` fixture to return `"groq/openai/gpt-oss-20b"` instead of Anthropic model  
- Update CI workflow to use `GROQ_API_KEY` instead of `ANTHROPIC_API_KEY`
- Add `test_model` parameter to all test functions that were using hard-coded models

## Test plan
- [x] All test files refactored to use fixture
- [x] `test_model` fixture updated to return Groq model
- [x] CI workflow updated to use Groq API key
- [x] GitHub secret `GROQ_API_KEY` configured
- [x] All syntax checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)